### PR TITLE
unsupported attribute basic settings removed from the module

### DIFF
--- a/examples/variable.tf
+++ b/examples/variable.tf
@@ -139,12 +139,6 @@ variable "common_configs" {
         })
       })))
     }))
-    basic_settings = optional(object({
-      client_secrets = optional(list(object({
-        client_secret            = optional(string)
-        client_secret_expires_at = optional(number)
-      })))
-    }))
     mfa = optional(object({
       setting                  = optional(string)
       time_interval_in_seconds = optional(number)

--- a/main.tf
+++ b/main.tf
@@ -96,7 +96,6 @@ locals {
     application_meta_data               = var.application_meta_data
     allow_guest_login                   = var.allow_guest_login
     group_role_restriction              = var.group_role_restriction
-    basic_settings                      = var.basic_settings
     mfa                                 = var.mfa
     social_providers                    = var.social_providers
     custom_providers                    = var.custom_providers
@@ -229,7 +228,6 @@ resource "cidaas_app" "app" {
   application_meta_data               = local.defaults["application_meta_data"]
   allow_guest_login                   = local.defaults["allow_guest_login"]
   group_role_restriction              = local.defaults["group_role_restriction"]
-  basic_settings                      = local.defaults["basic_settings"]
   mfa                                 = local.defaults["mfa"]
   social_providers                    = local.defaults["social_providers"]
   custom_providers                    = local.defaults["custom_providers"]

--- a/outputs.tf
+++ b/outputs.tf
@@ -608,7 +608,3 @@ output "backchannel_logout_session_required" {
   description = "Whether backchannel logout session is required"
 }
 
-output "basic_settings" {
-  value       = cidaas_app.app.basic_settings
-  description = "The basic settings configuration"
-}

--- a/variable.tf
+++ b/variable.tf
@@ -812,17 +812,6 @@ variable "group_role_restriction" {
   default     = null
 }
 
-variable "basic_settings" {
-  type = object({
-    client_secrets = optional(list(object({
-      client_secret            = optional(string)
-      client_secret_expires_at = optional(number)
-    })))
-  })
-  description = "Basic settings for the client."
-  default     = null
-}
-
 variable "common_configs" {
   type = object({
     client_type         = optional(string)
@@ -962,12 +951,6 @@ variable "common_configs" {
           match_condition = string
           roles           = list(string)
         })
-      })))
-    }))
-    basic_settings = optional(object({
-      client_secrets = optional(list(object({
-        client_secret            = optional(string)
-        client_secret_expires_at = optional(number)
       })))
     }))
     mfa = optional(object({


### PR DESCRIPTION
The Terraform module has been updated to address the issue caused by the removal of the attribute basic_settings in version 3.3.7 of the provider.